### PR TITLE
[이슈] 프리티어/린트 설정파일에서 마지막 요소에 컴마가 붙지 않도록 수정

### DIFF
--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -17,6 +17,7 @@ module.exports = {
     "plugin:prettier/recommended"
   ],
   rules: {
-    "prettier/prettier": 0
+    "prettier/prettier": 0,
+    "comma-dangle": ["error", "never"]
   }
 };

--- a/frontend/.prettierrc
+++ b/frontend/.prettierrc
@@ -1,0 +1,3 @@
+{
+  "trailingComma": "none"
+}

--- a/frontend/craco.config.js
+++ b/frontend/craco.config.js
@@ -6,8 +6,8 @@ module.exports = {
         source: "tsconfig",
         baseUrl: ".",
         tsConfigPath: "tsconfig.paths.json",
-        debug: false,
-      },
-    },
-  ],
+        debug: false
+      }
+    }
+  ]
 };

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -10,11 +10,7 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "declaration": true,
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "allowSyntheticDefaultImports": true,
     "noFallthroughCasesInSwitch": true,
@@ -23,12 +19,6 @@
     "isolatedModules": true,
     "noEmit": true
   },
-  "include": [
-    "src",
-    "craco.config.js"
-  ],
-  "exclude": [
-    "node_modules",
-    "dist"
-  ]
+  "include": ["src", "craco.config.js"],
+  "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
# 프리티어
```
{
  "trailingComma": "none"
}
```
# 린트
```
module.exports = {
  parser: "@typescript-eslint/parser",
  parserOptions: {
    sourceType: "module",
    ecmaFeatures: {
      jsx: true
    }
  },
  settings: {
    react: {
      version: "detect"
    }
  },
  extends: [
    "plugin:react/recommended",
    "plugin:@typescript-eslint/recommended",
    "plugin:prettier/recommended"
  ],
  rules: {
    "prettier/prettier": 0,
    "comma-dangle": ["error", "never"]
  }
};
```
